### PR TITLE
Add Comprehensive Tests for Meeting Creation API

### DIFF
--- a/payloads/meeting/payload_meeting.json
+++ b/payloads/meeting/payload_meeting.json
@@ -1,12 +1,12 @@
 {
   "status": "Planned",
-  "dateStart": "2024-07-01 15:15:00",
+  "dateStart": "2024-07-08 20:00:00",
   "duration": 3600,
-  "assignedUserId": "667c99fd0ee24b999",
-  "assignedUserName": "Jeyson Valdivia",
+  "assignedUserId": "66744ee8d0ffd7849",
+  "assignedUserName": "Admin",
   "acceptanceStatus": "None",
-  "dateEnd": "2024-07-01 16:15:00",
-  "name": "demo",
+  "dateEnd": "2024-07-08 21:00:00",
+  "name": "test_post_payload",
   "parentType": "Account",
   "parentName": "cuenta 123",
   "parentId": "667f373e22911f662",
@@ -14,40 +14,29 @@
   "isAllDay": false,
   "dateEndDate": null,
   "reminders": [],
-  "description": "reunion demo proyecto",
+  "description": "test description",
+  "teamsIds": [],
+  "teamsNames": {},
   "usersIds": [
-    "667c99fd0ee24b999",
-    "66797ce432cb83d06",
-    "66744ee8d0ffd7849"
+    "66744ee8d0ffd7849",
+    "667c99fd0ee24b999"
   ],
   "usersNames": {
-    "667c99fd0ee24b999": "Jeyson Valdivia",
-    "66797ce432cb83d06": "uva bombon",
-    "66744ee8d0ffd7849": "Admin"
+    "66744ee8d0ffd7849": "Admin",
+    "667c99fd0ee24b999": "Jeyson Valdivia"
   },
   "usersColumns": {
-    "667c99fd0ee24b999": {
-      "status": "None"
-    },
-    "66797ce432cb83d06": {
-      "status": "None"
-    },
     "66744ee8d0ffd7849": {
+      "status": "None"
+    },
+    "667c99fd0ee24b999": {
       "status": "None"
     }
   },
   "contactsIds": [],
   "contactsNames": {},
   "contactsColumns": {},
-  "leadsIds": [
-    "667b9c285193dbb98"
-  ],
-  "leadsNames": {
-    "667b9c285193dbb98": "Alison Guzman"
-  },
-  "leadsColumns": {
-    "667b9c285193dbb98": {
-      "status": "None"
-    }
-  }
+  "leadsIds": [],
+  "leadsNames": {},
+  "leadsColumns": {}
 }

--- a/tests/presentations/test_post_meeting.py
+++ b/tests/presentations/test_post_meeting.py
@@ -7,7 +7,7 @@ from api_endpoints.api_request import EspoCRMRequest
 import allure
 
 @allure.feature('Presentations - Jeyson Valdivia')
-@allure.story('Get Presentations')
+@allure.story('Create Presentations')
 @pytest.mark.functional
 @pytest.mark.smoke
 def test_post_meeting_success(get_headers, base_payload, teardown_delete_meeting):
@@ -20,7 +20,7 @@ def test_post_meeting_success(get_headers, base_payload, teardown_delete_meeting
     teardown_delete_meeting.append(meeting_id)
 
 @allure.feature('Presentations - Jeyson Valdivia')
-@allure.story('Get Presentations')
+@allure.story('Create Presentations')
 @pytest.mark.functional
 @pytest.mark.regression
 def test_post_meetings_schema_validation(get_headers, base_payload, teardown_delete_meeting):
@@ -31,8 +31,9 @@ def test_post_meetings_schema_validation(get_headers, base_payload, teardown_del
     assert_payload_presentation_schema(response.json())
     meeting_id = response.json().get('id')
     teardown_delete_meeting.append(meeting_id)
+
 @allure.feature('Presentations - Jeyson Valdivia')
-@allure.story('Get Presentations')
+@allure.story('Create Presentations')
 @pytest.mark.functional
 @pytest.mark.smoke
 def test_post_meeting_with_invalid_auth(get_headers, base_payload):
@@ -43,11 +44,192 @@ def test_post_meeting_with_invalid_auth(get_headers, base_payload):
     assert_status_code_unauthorized(response)
 
 @allure.feature('Presentations - Jeyson Valdivia')
-@allure.story('Get Presentations')
+@allure.story('Create Presentations')
 @pytest.mark.functional
 @pytest.mark.smoke
 def test_post_meetings_unauthorized(base_payload):
     url = MeetingEndpoints.create_meeting()
-    response = EspoCRMRequest.post_without_headers(url,base_payload)
+    response = EspoCRMRequest.post_without_headers(url, base_payload)
+
+    assert_status_code_unauthorized(response)
+
+@allure.feature('Presentations - Jeyson Valdivia')
+@allure.story('Create Presentations')
+@pytest.mark.functional
+def test_post_meeting_missing_status(get_headers, base_payload):
+    url = MeetingEndpoints.create_meeting()
+    headers = Auth().auth_valid_credential(get_headers)
+    base_payload.pop('status', None)
+    response = EspoCRMRequest.post_json(url, headers, base_payload)
+
+    assert_status_bad_request(response)
+
+@allure.feature('Presentations - Jeyson Valdivia')
+@allure.story('Create Presentations')
+@pytest.mark.functional
+def test_post_meeting_missing_date_start(get_headers, base_payload):
+    url = MeetingEndpoints.create_meeting()
+    headers = Auth().auth_valid_credential(get_headers)
+    base_payload.pop('dateStart', None)
+    response = EspoCRMRequest.post_json(url, headers, base_payload)
+
+    assert_status_bad_request(response)
+
+@allure.feature('Presentations - Jeyson Valdivia')
+@allure.story('Create Presentations')
+@pytest.mark.functional
+def test_post_meeting_negative_duration(get_headers, base_payload):
+    url = MeetingEndpoints.create_meeting()
+    headers = Auth().auth_valid_credential(get_headers)
+    base_payload['duration'] = -1
+    response = EspoCRMRequest.post_json(url, headers, base_payload)
+
+    assert_status_bad_request(response)
+
+@allure.feature('Presentations - Jeyson Valdivia')
+@allure.story('Create Presentations')
+@pytest.mark.functional
+def test_post_meeting_missing_assigned_user_id(get_headers, base_payload):
+    url = MeetingEndpoints.create_meeting()
+    headers = Auth().auth_valid_credential(get_headers)
+    base_payload.pop('assignedUserId', None)
+    response = EspoCRMRequest.post_json(url, headers, base_payload)
+
+    assert_status_bad_request(response)
+
+@allure.feature('Presentations - Jeyson Valdivia')
+@allure.story('Create Presentations')
+@pytest.mark.functional
+def test_post_meeting_invalid_status(get_headers, base_payload):
+    url = MeetingEndpoints.create_meeting()
+    headers = Auth().auth_valid_credential(get_headers)
+    base_payload['status'] = 'InvalidStatus'
+    response = EspoCRMRequest.post_json(url, headers, base_payload)
+
+    assert_status_bad_request(response)
+
+@allure.feature('Presentations - Jeyson Valdivia')
+@allure.story('Create Presentations')
+@pytest.mark.functional
+def test_post_meeting_without_date_end(get_headers, base_payload):
+    url = MeetingEndpoints.create_meeting()
+    headers = Auth().auth_valid_credential(get_headers)
+    base_payload.pop('dateEnd', None)
+    response = EspoCRMRequest.post_json(url, headers, base_payload)
+
+    assert_status_bad_request(response)
+
+@allure.feature('Presentations - Jeyson Valdivia')
+@allure.story('Create Presentations')
+@pytest.mark.functional
+def test_post_meeting_with_all_day(get_headers, base_payload, teardown_delete_meeting):
+    url = MeetingEndpoints.create_meeting()
+    headers = Auth().auth_valid_credential(get_headers)
+    base_payload['isAllDay'] = True
+    response = EspoCRMRequest.post_json(url, headers, base_payload)
+
+    assert_status_code_created(response)
+    meeting_id = response.json().get('id')
+    teardown_delete_meeting.append(meeting_id)
+
+@allure.feature('Presentations - Jeyson Valdivia')
+@allure.story('Create Presentations')
+@pytest.mark.functional
+def test_post_meeting_invalid_parent_type(get_headers, base_payload):
+    url = MeetingEndpoints.create_meeting()
+    headers = Auth().auth_valid_credential(get_headers)
+    base_payload['parentType'] = 'InvalidParentType'
+    response = EspoCRMRequest.post_json(url, headers, base_payload)
+
+    assert_status_bad_request(response)
+
+@allure.feature('Presentations - Jeyson Valdivia')
+@allure.story('Create Presentations')
+@pytest.mark.functional
+def test_post_meeting_empty_reminder(get_headers, base_payload, teardown_delete_meeting):
+    url = MeetingEndpoints.create_meeting()
+    headers = Auth().auth_valid_credential(get_headers)
+    base_payload['reminders'] = {}
+    response = EspoCRMRequest.post_json(url, headers, base_payload)
+
+    assert_status_code_created(response)
+    meeting_id = response.json().get('id')
+    teardown_delete_meeting.append(meeting_id)
+
+@allure.feature('Presentations - Jeyson Valdivia')
+@allure.story('Create Presentations')
+@pytest.mark.functional
+def test_post_meeting_empty_description(get_headers, base_payload, teardown_delete_meeting):
+    url = MeetingEndpoints.create_meeting()
+    headers = Auth().auth_valid_credential(get_headers)
+    base_payload['description'] = ""
+    response = EspoCRMRequest.post_json(url, headers, base_payload)
+
+    assert_status_code_created(response)
+    meeting_id = response.json().get('id')
+    teardown_delete_meeting.append(meeting_id)
+
+@allure.feature('Presentations - Jeyson Valdivia')
+@allure.story('Create Presentations')
+@pytest.mark.functional
+def test_post_meeting_invalid_date_start_format(get_headers, base_payload):
+    url = MeetingEndpoints.create_meeting()
+    headers = Auth().auth_valid_credential(get_headers)
+    base_payload['dateStart'] = 'InvalidDateFormat'
+    response = EspoCRMRequest.post_json(url, headers, base_payload)
+
+    assert_status_bad_request(response)
+
+@allure.feature('Presentations - Jeyson Valdivia')
+@allure.story('Create Presentations')
+@pytest.mark.functional
+def test_post_meeting_past_date_start(get_headers, base_payload):
+    url = MeetingEndpoints.create_meeting()
+    headers = Auth().auth_valid_credential(get_headers)
+    base_payload['dateStart'] = '2000-01-01T00:00:00Z'
+    response = EspoCRMRequest.post_json(url, headers, base_payload)
+
+    assert_status_bad_request(response)
+
+@allure.feature('Presentations - Jeyson Valdivia')
+@allure.story('Create Presentations')
+@pytest.mark.functional
+def test_post_meeting_string_duration(get_headers, base_payload):
+    url = MeetingEndpoints.create_meeting()
+    headers = Auth().auth_valid_credential(get_headers)
+    base_payload['duration'] = 'string'
+    response = EspoCRMRequest.post_json(url, headers, base_payload)
+
+    assert_status_bad_request(response)
+
+@allure.feature('Presentations - Jeyson Valdivia')
+@allure.story('Create Presentations')
+@pytest.mark.functional
+def test_post_meeting_string_users_ids(get_headers, base_payload):
+    url = MeetingEndpoints.create_meeting()
+    headers = Auth().auth_valid_credential(get_headers)
+    base_payload['usersIds'] = 'string'
+    response = EspoCRMRequest.post_json(url, headers, base_payload)
+
+    assert_status_bad_request(response)
+
+@allure.feature('Presentations - Jeyson Valdivia')
+@allure.story('Create Presentations')
+@pytest.mark.functional
+def test_post_meeting_invalid_input_data(get_headers, base_payload):
+    url = MeetingEndpoints.create_meeting()
+    headers = Auth().auth_valid_credential(get_headers)
+    base_payload['invalidField'] = 'InvalidData'
+    response = EspoCRMRequest.post_json(url, headers, base_payload)
+
+    assert_status_bad_request(response)
+
+@allure.feature('Presentations - Jeyson Valdivia')
+@allure.story('Create Presentations')
+@pytest.mark.functional
+@pytest.mark.smoke
+def test_post_meeting_without_credentials(base_payload):
+    url = MeetingEndpoints.create_meeting()
+    response = EspoCRMRequest.post_without_headers(url, base_payload)
 
     assert_status_code_unauthorized(response)


### PR DESCRIPTION
This PR enhances the existing test suite by adding new test cases to thoroughly validate the functionality of the Meeting Creation API. The new tests ensure robust validation, security, and error handling for meeting creation scenarios. Additionally, improvements and bug fixes have been implemented based on the feedback and initial test runs.

Changes Introduced:

New Test Cases:

- test_post_meeting_success: Verifies that a meeting can be created successfully with all valid fields.
- test_post_meetings_schema_validation: Validates the response schema after creating a meeting.
- test_post_meeting_with_invalid_auth: Ensures meeting creation fails with invalid authentication.
- test_post_meetings_unauthorized: Ensures meeting creation fails without authorization.
- test_post_meeting_missing_status: Ensures meeting creation fails without the status field.
- test_post_meeting_missing_date_start: Ensures meeting creation fails without the dateStart field.
- test_post_meeting_negative_duration: Ensures meeting creation fails with a negative duration.
- test_post_meeting_missing_assigned_user_id: Ensures meeting creation fails without assignedUserId.
- test_post_meeting_invalid_status: Ensures meeting creation fails with an invalid status.
- test_post_meeting_without_date_end: Ensures meeting creation succeeds without the dateEnd field.
- test_post_meeting_with_all_day: Verifies meeting creation with isAllDay set to true.
- test_post_meeting_invalid_parent_type: Ensures meeting creation fails with an invalid parentType.
- test_post_meeting_empty_reminder: Verifies meeting creation with an empty reminder is successful.
- test_post_meeting_empty_description: Verifies meeting creation with an empty description is successful.
- test_post_meeting_invalid_date_start_format: Ensures meeting creation fails with dateStart in an invalid format.
- test_post_meeting_past_date_start: Ensures meeting creation fails with dateStart in the past.
- test_post_meeting_string_duration: Ensures meeting creation fails with duration as a string.
- test_post_meeting_string_users_ids: Ensures meeting creation fails with usersIds as a string.
- test_post_meeting_invalid_input_data: Ensures meeting creation fails with invalid input data.
- test_post_meeting_without_credentials: Ensures meeting creation fails without access credentials.

Improvements:

- Updated test payloads for consistency and completeness.
- Enhanced error logging for better debugging and issue tracking.
![image](https://github.com/Jasonn5/Qates/assets/98439093/12beb32d-f644-46eb-b2c9-ea73df55d0f2)
