### PR TITLE
Scrum_76_delete_pressentations

### DIFF
--- a/api_endpoints/api_request.py
+++ b/api_endpoints/api_request.py
@@ -23,11 +23,6 @@ class EspoCRMRequest:
 
 
     @staticmethod
-    def delete(url, headers):
-        response = requests.post(url, headers=headers)
-        return response
-
-    @staticmethod
     def post_json(url, headers, payload):
         response = requests.post(url, headers=headers, json=payload)
         return response
@@ -35,4 +30,14 @@ class EspoCRMRequest:
     @staticmethod
     def post_without_headers(url, payload):
         response = requests.post(url, json=payload)
+        return response
+
+    @staticmethod
+    def delete(url, headers):
+        response = requests.delete(url, headers=headers)
+        return response
+
+    @staticmethod
+    def delete_without_headers(url):
+        response = requests.delete(url)
         return response

--- a/api_endpoints/meeting_endpoints.py
+++ b/api_endpoints/meeting_endpoints.py
@@ -10,6 +10,10 @@ class MeetingEndpoints:
         return f"{BASE_URI}/Meeting?{params}"
 
     @staticmethod
+    def get_meeting_by_id(meeting_id):
+        return f"{BASE_URI}/Meeting/{meeting_id}"
+
+    @staticmethod
     def create_meeting() -> str:
         return f"{BASE_URI}/Meeting"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,7 +6,8 @@ def get_headers():
     def _get_headers(username, password):
         espo_authorization = encoded(username, password)
         return {
-            'Espo-Authorization': espo_authorization
+            'Espo-Authorization': espo_authorization,
+            'Cookie': 'auth-token-secret=b51d5dc9ee9eafa0aaa329612425ad63; auth-token=288eacade0b7e816569a85a5d07f165a'
         }
 
     return _get_headers

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,8 +6,7 @@ def get_headers():
     def _get_headers(username, password):
         espo_authorization = encoded(username, password)
         return {
-            'Espo-Authorization': espo_authorization,
-            'Cookie': 'auth-token-secret=b51d5dc9ee9eafa0aaa329612425ad63; auth-token=288eacade0b7e816569a85a5d07f165a'
+            'Espo-Authorization': espo_authorization
         }
 
     return _get_headers

--- a/tests/presentations/conftest.py
+++ b/tests/presentations/conftest.py
@@ -3,11 +3,20 @@ import json
 from api_endpoints.meeting_endpoints import MeetingEndpoints
 from api_endpoints.api_request import EspoCRMRequest
 from resources.auth.auth import Auth
+
 @pytest.fixture(scope="module")
 def base_payload():
     with open('payloads/meeting/payload_meeting.json', 'r') as file:
         return json.load(file)
 
+@pytest.fixture(scope="function")
+def setup_create_meeting(get_headers, base_payload):
+    headers = Auth().auth_valid_credential(get_headers)
+    url = MeetingEndpoints.create_meeting()
+    response = EspoCRMRequest.post_json(url, headers, base_payload)
+    meeting_id = response.json().get('id')
+
+    yield headers, meeting_id
 
 @pytest.fixture(scope="function")
 def teardown_delete_meeting(get_headers):

--- a/tests/presentations/test_delete_meeting.py
+++ b/tests/presentations/test_delete_meeting.py
@@ -1,0 +1,106 @@
+import pytest
+from assertions.assertion_status import *
+from resources.auth.auth import Auth
+from api_endpoints.meeting_endpoints import MeetingEndpoints
+from api_endpoints.api_request import EspoCRMRequest
+from assertions.assertion_headers import *
+import allure
+
+@allure.feature('Presentations - Jeyson Valdivia')
+@allure.story('Delete Presentations')
+@pytest.mark.functional
+@pytest.mark.smoke
+def test_delete_existing_meeting(setup_create_meeting):
+    headers, meeting_id = setup_create_meeting
+    print(meeting_id)
+    delete_url = MeetingEndpoints.delete_meeting(meeting_id)
+    response = EspoCRMRequest.delete(delete_url, headers)
+    assert_status_code_ok(response)
+
+@allure.feature('Presentations - Jeyson Valdivia')
+@allure.story('Delete Presentations')
+@pytest.mark.functional
+@pytest.mark.regression
+def test_delete_non_existent_meeting(get_headers):
+    non_existent_meeting_id = "nonExistentMeetingId"
+    url = MeetingEndpoints.delete_meeting(non_existent_meeting_id)
+    headers = Auth().auth_valid_credential(get_headers)
+    response = EspoCRMRequest.delete(url, headers)
+    assert_status_code_not_found(response)
+
+@allure.feature('Presentations - Jeyson Valdivia')
+@allure.story('Delete Presentations')
+@pytest.mark.smoke
+@pytest.mark.functional
+def test_delete_meeting_without_auth(setup_create_meeting):
+    _, meeting_id = setup_create_meeting
+    delete_url = MeetingEndpoints.delete_meeting(meeting_id)
+    response = EspoCRMRequest.delete_without_headers(delete_url)
+    assert_status_code_unauthorized(response)
+
+@allure.feature('Presentations - Jeyson Valdivia')
+@allure.story('Delete Presentations')
+@pytest.mark.functional
+@pytest.mark.smoke
+def test_delete_meeting_returns_ok(setup_create_meeting):
+    headers, meeting_id = setup_create_meeting
+    delete_url = MeetingEndpoints.delete_meeting(meeting_id)
+    response = EspoCRMRequest.delete(delete_url, headers)
+    assert_status_code_ok(response)
+
+@allure.feature('Presentations - Jeyson Valdivia')
+@allure.story('Delete Presentations')
+@pytest.mark.functional
+@pytest.mark.regression
+def test_deleted_meeting_not_recoverable(get_headers, setup_create_meeting):
+    headers, meeting_id = setup_create_meeting
+    delete_url = MeetingEndpoints.delete_meeting(meeting_id)
+    delete_response = EspoCRMRequest.delete(delete_url, headers)
+    assert_status_code_ok(delete_response)
+    get_url = MeetingEndpoints.get_meeting_by_id(meeting_id)
+    get_response = EspoCRMRequest.get_with_url_headers(get_url, headers)
+    assert_status_code_not_found(get_response)
+
+@allure.feature('Presentations - Jeyson Valdivia')
+@allure.story('Delete Presentations')
+@pytest.mark.functional
+@pytest.mark.regression
+def test_delete_meeting_invalid_id(get_headers):
+    invalid_meeting_id = "invalidId!@#"
+    url = MeetingEndpoints.delete_meeting(invalid_meeting_id)
+    headers = Auth().auth_valid_credential(get_headers)
+    response = EspoCRMRequest.delete(url, headers)
+    assert_status_code_not_found(response)
+
+@allure.feature('Presentations - Jeyson Valdivia')
+@allure.story('Delete Presentations')
+@pytest.mark.smoke
+@pytest.mark.functional
+def test_delete_meeting_unauthorized_user(get_headers, setup_create_meeting):
+    _, meeting_id = setup_create_meeting
+    delete_url = MeetingEndpoints.delete_meeting(meeting_id)
+    unauthorized_headers = Auth().auth_invalid_credentials(get_headers)
+    response = EspoCRMRequest.delete(delete_url, unauthorized_headers)
+    assert_status_code_unauthorized(response)
+
+@allure.feature('Presentations - Jeyson Valdivia')
+@allure.story('Delete Presentations')
+@pytest.mark.functional
+def test_delete_meeting_expected_headers(get_headers, setup_create_meeting):
+    headers, meeting_id = setup_create_meeting
+    delete_url = MeetingEndpoints.delete_meeting(meeting_id)
+    delete_response = EspoCRMRequest.delete(delete_url, headers)
+    assert_status_code_ok(delete_response)
+    assert_content_type_application_json(delete_response)
+    assert 'Date' in delete_response.headers
+    assert 'Server' in delete_response.headers
+
+@allure.feature('Presentations - Jeyson Valdivia')
+@allure.story('Delete Presentations')
+@pytest.mark.functional
+def test_delete_meeting_confirmation_response_body(get_headers, setup_create_meeting):
+    headers, meeting_id = setup_create_meeting
+    delete_url = MeetingEndpoints.delete_meeting(meeting_id)
+    delete_response = EspoCRMRequest.delete(delete_url, headers)
+    assert_status_code_ok(delete_response)
+    assert delete_response.text == 'true'


### PR DESCRIPTION
This pull request introduces a comprehensive suite of test cases for meeting deletion functionality within the EspoCRM API. The focus is to ensure robustness and reliability of the delete operation under various scenarios. The tests are designed to validate proper API behavior, including successful deletion, handling of invalid requests, and correct response codes.

Setup Method:
Function: setup_create_meeting
Purpose: Creates a meeting before each test to ensure there is a valid meeting available for deletion.
Details:

- Generates headers using valid credentials.
- Creates a meeting and yields its ID along with the headers for use in the test.
Test Cases Implemented:

Test Method: test_delete_existing_meeting =>  Expected Result: 200 OK
Test Method: test_delete_non_existent_meeting =>Expected Result: 404 Not Found
Test Method: test_delete_meeting_without_auth => Expected Result: 401 Unauthorized
Test Method: test_delete_meeting_returns_ok => Expected Result: 200 OK
Test Method: test_deleted_meeting_not_recoverable => Expected Result: 404 Not Found
Test Method: test_delete_meeting_invalid_id => Expected Result: 404 Not Found
Test Method: test_delete_meeting_unauthorized_user => Expected Result: 401 Unauthorized
Test Method: test_delete_meeting_expected_headers =>xpected Result: Valid headers in response

Test Method: test_delete_meeting_confirmation_response_body
Expected Result: Response body 'true'
Ensures: Proper response body format.
![image](https://github.com/Jasonn5/Qates/assets/98439093/5cbc92d5-bc2b-4be3-9fad-e398a9c7571a)
