### PR TITLE
SCRUM-52-DELETE menssages

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -127,3 +127,7 @@ CALL_REQUIRED_AND_OPTIONAL_DATA = {
         }
     }
 }
+IMPORTANT_EMAIL_PAYLOAD = {
+    "emailId": "importantEmailId",
+    "isImportant": True
+}

--- a/tests/mail_important/test_delete_email_important.py
+++ b/tests/mail_important/test_delete_email_important.py
@@ -1,0 +1,89 @@
+import pytest
+import allure
+from api_endpoints.api_request import EspoCRMRequest
+from config.config import BASE_URI
+from resources.auth.auth import Auth
+from assertions.assertion_status import (
+    assert_status_code_ok,
+    assert_status_code_unauthorized,
+    assert_status_code_forbidden,
+    assert_status_bad_request
+)
+
+@pytest.mark.smoke
+@pytest.mark.functional
+@pytest.mark.regression
+@allure.feature('Email Important')
+@allure.story('Delete Email Important')
+def test_delete_email_important_success(get_headers, create_important_email):
+    """
+    Verify successful deletion of important email - status code 200 OK
+    """
+    email_id = create_important_email()
+    url = f"{BASE_URI}/Email/inbox/important/{email_id}"
+    headers = Auth().auth_valid_credential(get_headers)
+    response = EspoCRMRequest.delete(url, headers)
+    assert_status_code_ok(response)
+
+@pytest.mark.smoke
+@pytest.mark.functional
+@pytest.mark.regression
+@allure.feature('Email Important')
+@allure.story('Delete Email Important')
+def test_delete_multiple_important_emails(get_headers, create_important_email):
+    """
+    Verify deletion of multiple important emails - status code 200 OK
+    """
+    email_ids = [create_important_email() for _ in range(2)]
+    headers = Auth().auth_valid_credential(get_headers)
+
+    for email_id in email_ids:
+        url = f"{BASE_URI}/Email/inbox/important/{email_id}"
+        response = EspoCRMRequest.delete(url, headers)
+        assert_status_code_ok(response)
+
+@pytest.mark.smoke
+@pytest.mark.functional
+@pytest.mark.regression
+@allure.feature('Email Important')
+@allure.story('Delete Email Important')
+def test_delete_email_important_without_auth_header(create_important_email):
+    """
+    Verify deletion of important email without authorization header - status code 401 Unauthorized
+    """
+    email_id = create_important_email()
+    url = f"{BASE_URI}/Email/inbox/important/{email_id}"
+    headers = {}
+    response = EspoCRMRequest.delete(url, headers)
+    assert_status_code_unauthorized(response)
+
+@pytest.mark.smoke
+@pytest.mark.functional
+@pytest.mark.regression
+@allure.feature('Email Important')
+@allure.story('Delete Email Important')
+def test_delete_email_important_invalid_auth_token(get_headers, create_important_email):
+    """
+    Verify deletion of important email with invalid authorization token - status code 401 Unauthorized
+    """
+    email_id = create_important_email()
+    url = f"{BASE_URI}/Email/inbox/important/{email_id}"
+    headers = {"Authorization": "Basic invalidcredentials"}
+    response = EspoCRMRequest.delete(url, headers)
+    assert_status_code_unauthorized(response)
+
+@pytest.mark.smoke
+@pytest.mark.functional
+@pytest.mark.regression
+@allure.feature('Email Important')
+@allure.story('Delete Email Important')
+def test_delete_email_important_check_response_content_type(get_headers, create_important_email):
+    """
+    Verify deletion of important email and check response content type - status code 200 OK
+    """
+    email_id = create_important_email()
+    url = f"{BASE_URI}/Email/inbox/important/{email_id}"
+    headers = Auth().auth_valid_credential(get_headers)
+    response = EspoCRMRequest.delete(url, headers)
+    assert_status_code_ok(response)
+    assert response.headers['Content-Type'] == 'application/json'


### PR DESCRIPTION
Add code for my test cases
Added test cases:
test_delete_email_important_success`: Verifies successful deletion of a single important email.
test_delete_multiple_important_emails`: Tests deletion of multiple important emails.
test_delete_email_important_without_auth_header`: Checks unauthorized deletion without auth header.
test_delete_email_important_invalid_auth_token`: Ensures unauthorized deletion with invalid token.
test_delete_email_important_check_response_content_type`: Validates response content type after deletion.
For the moment, I found 5 bugs
![image](https://github.com/Jasonn5/Qates/assets/55772207/a4260959-00c3-455a-98f8-47c63d840f0f)
